### PR TITLE
認証後に登録するユーザーデータを見直し、userテーブルの更新

### DIFF
--- a/backend/app/Http/Middleware/CognitoJwtAuth.php
+++ b/backend/app/Http/Middleware/CognitoJwtAuth.php
@@ -124,11 +124,8 @@ class CognitoJwtAuth
     private function getUserFromPayload(object $payload): ?User
     {
         $cognitoSub = $payload->sub;
-        $userData = [
-            'name' => $payload->username ?? $payload->{'cognito:username'} ?? '',
-        ];
 
-        return User::findOrCreateByCognitoSub($cognitoSub, $userData);
+        return User::findOrCreateByCognitoSub($cognitoSub);
     }
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -12,52 +12,49 @@ class User extends Authenticatable
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
     protected $fillable = [
         'name',
-        'email',
+        'user_id',
         'cognito_sub',
-    ];
+        'couple_id',
+        'pair_index',
 
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        // Cognito認証を使用するため、password関連フィールドは削除済み
     ];
-
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
-    protected function casts(): array
-    {
-        return [
-            // Cognito認証を使用するため、password関連フィールドは削除済み
-        ];
-    }
 
     /**
      * Cognito SubでユーザーをIDで検索、存在しない場合は作成
      */
-    public static function findOrCreateByCognitoSub(string $cognitoSub, array $userData): self
+    public static function findOrCreateByCognitoSub(string $cognitoSub): User
     {
         $user = User::where('cognito_sub', $cognitoSub)->first();
 
         if (!$user) {
+            $userId = self::generateUserId();
             $user = User::create([
                 'cognito_sub' => $cognitoSub,
-                'name' => $userData['name'] ?? '',
+                'name' => $userId,
+                'user_id' => $userId,
             ]);
         }
 
         return $user;
+    }
+
+    /**
+     * ユーザーIDを生成
+     */
+    private function generateUserId(): string
+    {
+        $chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+        $length = 10;
+
+        do {
+            $userId = '';
+            for ($i = 0; $i < $length; $i++) {
+                $userId .= $chars[random_int(0, strlen($chars) - 1)];
+            }
+        } while (User::where('user_id', $userId)->exists());
+
+        return $userId;
     }
 }

--- a/backend/database/migrations/2025_09_20_105829_update_name_and_add_user_id_to_users_table.php
+++ b/backend/database/migrations/2025_09_20_105829_update_name_and_add_user_id_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('user_id', 10)->after('name')->unique();
+            $table->string('name', 10)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+            $table->string('name', 255)->change();
+        });
+    }
+};


### PR DESCRIPTION
ログイン後に表示される名前を変更可能なものにするため、以下の処理を実装
- user_idを追加し、一意なidを設定
- nameに表示名を入力
- cognito_subはバックエンドのみで使用