### PR TITLE
明細記録のコンポーネント整理

### DIFF
--- a/backend/app/Http/Controllers/Api/ExpenseReportController.php
+++ b/backend/app/Http/Controllers/Api/ExpenseReportController.php
@@ -43,8 +43,12 @@ class ExpenseReportController extends Controller
             }
 
             $sortedByCategoryData[$groupCode]['categories'][$categoryCode]['payments'][] = [
-                'payment_date' => $payment->payment_date,
+                'id' => $payment->id,
                 'amount' => $payment->amount,
+                'category_id' => $payment->category_id,
+                'payment_date' => $payment->payment_date,
+                'paid_by_user_id' => $payment->paid_by_user_id,
+                'couple_id' => $payment->couple_id,
                 'store_name' => $payment->store_name,
                 'note' => $payment->note,
             ];

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -25,7 +25,6 @@ export default function DashboardPage() {
     const fetchExpenseReport = async () => {
       try {
         const response = await getExpenseReport();
-        console.log(response);
         setExpenseReport(response);
       } catch (error) {
         console.error("支出管理表の取得に失敗しました:", error);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, ReactNode } from "react";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import AmplifyProvider from "@/components/auth/AmplifyProvider.tsx";
 import { AuthProvider } from "@/contexts/AuthContext.tsx";
+import { CategoryProvider } from "@/contexts/CategoryContext.tsx";
 import { Footer } from "@/components/layout/Footer.tsx";
 import { Header } from "@/components/layout/Header.tsx";
 
@@ -44,18 +45,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="antialiased">
         <AmplifyProvider>
           <AuthProvider>
-            <Header
-              // isLoading={isLoading}
-              // isAuth={isAuth}
-              // setIsAuth={setIsAuth}
-              // user={user}
-              // setUser={setUser}
-              finance={finance}
-              setFinance={setFinance}
-            />
-            {children}
-            <Toaster position="top-center" richColors />
-            <Footer />
+            <CategoryProvider>
+              <Header finance={finance} setFinance={setFinance} />
+              {children}
+              <Toaster position="top-center" richColors />
+              <Footer />
+            </CategoryProvider>
           </AuthProvider>
         </AmplifyProvider>
       </body>

--- a/frontend/src/components/dashboard/ExpenseReport/TransactionDetailDialog.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/TransactionDetailDialog.tsx
@@ -1,30 +1,16 @@
-import { useState, useEffect } from "react";
-import { Button } from "@/components/ui/button.tsx";
 import {
   Dialog,
-  DialogClose,
   DialogContent,
-  DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog.tsx";
-import { CategoryList } from "@/components/dashboard/Transaction/CategoryList.tsx";
-import { Memo } from "@/components/dashboard/Transaction/Memo.tsx";
-import { PayerSelect } from "@/components/dashboard/Transaction/PayerSelect.tsx";
-import { RegisteredDate } from "@/components/dashboard/Transaction/RegisteredDate.tsx";
-import { ShopInfo } from "@/components/dashboard/Transaction/ShopInfo.tsx";
-import { Amount } from "@/components/dashboard/Transaction/Amount.tsx";
-import { Payment, CategoryData, TransactionData } from "@/types/transaction.ts";
+import { updateTransactionData } from "@/types/transaction.ts";
 import { useAuth } from "@/contexts/AuthContext.tsx";
-import { getCategories } from "@/lib/api.ts";
-import { toast } from "sonner";
-import { format } from "date-fns";
-import { postTransaction } from "@/lib/api.ts";
-import { CategorySelection } from "@/types/transaction.ts";
+import { useTransactionForm } from "@/hooks/useTransactionForm.tsx";
+import { TransactionForm } from "../Transaction/TransactionForm";
 
 interface TransactionDetailDialogProps {
-  payment: Payment;
+  payment: updateTransactionData;
   isOpen: boolean;
   onClose: () => void;
 }
@@ -34,100 +20,22 @@ export function TransactionDetailDialog({
   isOpen,
   onClose,
 }: TransactionDetailDialogProps) {
-  const [categories, setCategories] = useState<CategoryData>({});
-  const { userInfo, isAuth } = useAuth();
-  const [transactionData, setTransactionData] = useState<TransactionData>({
-    user: userInfo.user_id,
-    amount: 0,
-    date: new Date(),
-    category: null,
-    payer: userInfo.user_id,
-    shop_name: "",
-    memo: "",
+  const { userInfo } = useAuth();
+  const {
+    categories,
+    transactionData,
+    isSaveDisabled,
+    handleAmountChange,
+    handleDateChange,
+    handleCategoryChange,
+    handlePayerChange,
+    handleShopNameChange,
+    handleMemoChange,
+    handleSave,
+  } = useTransactionForm({
+    transactionPatch: { ...payment },
+    onSaveSuccess: onClose,
   });
-
-  useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        const response = await getCategories();
-
-        if (response.status) {
-          setCategories(response.data);
-        }
-      } catch (err) {
-        toast.error("カテゴリーの取得に失敗しました", {
-          className: "!bg-red-600 !text-white !border-red-800",
-        });
-      }
-    };
-
-    if (isAuth) {
-      void fetchCategories();
-    }
-  }, []);
-
-  const handleAmountChange = (amount: number) => {
-    setTransactionData((prev) => ({ ...prev, amount }));
-  };
-
-  const handleDateChange = (date: Date) => {
-    setTransactionData((prev) => ({ ...prev, date }));
-  };
-
-  const handleCategoryChange = (category: CategorySelection | null) => {
-    setTransactionData((prev) => ({ ...prev, category }));
-  };
-
-  const handlePayerChange = (payer: string) => {
-    setTransactionData((prev) => ({ ...prev, payer }));
-  };
-
-  const handleShopNameChange = (shop_name: string) => {
-    setTransactionData((prev) => ({ ...prev, shop_name }));
-  };
-
-  const handleMemoChange = (memo: string) => {
-    setTransactionData((prev) => ({ ...prev, memo }));
-  };
-
-  const isSaveDisabled =
-    transactionData.amount <= 0 || transactionData.category === null;
-
-  const handleSave = async () => {
-    try {
-      const requestData = {
-        ...transactionData,
-        date: format(transactionData.date, "yyyy-MM-dd"),
-        category: parseInt(transactionData.category?.value || ""),
-      };
-
-      const response = await postTransaction(requestData);
-
-      if (response.status) {
-        toast.success("取引明細を保存しました", {
-          className: "!bg-yellow-600 !text-white !border-yellow-800",
-        });
-      } else {
-        toast.error("取引明細の保存に失敗しました", {
-          className: "!bg-red-600 !text-white !border-red-800",
-        });
-      }
-    } catch (error) {
-      toast.error("取引明細の保存に失敗しました", {
-        className: "!bg-red-600 !text-white !border-red-800",
-      });
-    } finally {
-      setTransactionData((prev) => ({
-        ...prev,
-        amount: 0,
-        date: new Date(),
-        category: null,
-        payer: userInfo.user_id,
-        shop_name: "",
-        memo: "",
-      }));
-    }
-  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -136,62 +44,20 @@ export function TransactionDetailDialog({
           <DialogTitle>明細の編集</DialogTitle>
         </DialogHeader>
         <div className="space-y-7">
-          {/* 金額 */}
-          <div className="flex justify-between items-end gap-2">
-            <Amount
-              amount={transactionData.amount}
-              onAmountChange={handleAmountChange}
-            />
-          </div>
-
-          <div className="flex items-center gap-4">
-            {/* 登録日 */}
-            <div className="w-1/2">
-              <RegisteredDate
-                date={transactionData.date}
-                onDateChange={handleDateChange}
-              />
-            </div>
-            {/* カテゴリー */}
-            <div className="w-1/2">
-              <CategoryList
-                categories={categories}
-                selected={transactionData.category}
-                onSelectionChange={handleCategoryChange}
-              />
-            </div>
-          </div>
-
-          {/* 支払者 */}
-          <div className="flex justify-between items-center">
-            <PayerSelect
-              userInfo={userInfo}
-              payer={transactionData.payer}
-              onPayerChange={handlePayerChange}
-            />
-          </div>
-          <div className="bg-gray-100 p-2 text-center">支出の詳細</div>
-
-          {/* お店の名前 */}
-          <div>
-            <ShopInfo
-              shop_name={transactionData.shop_name}
-              onShopNameChange={handleShopNameChange}
-            />
-          </div>
-
-          {/* メモ */}
-          <div>
-            <Memo memo={transactionData.memo} onMemoChange={handleMemoChange} />
-          </div>
-
-          <Button
-            className="w-full text-xl h-12"
-            onClick={handleSave}
-            disabled={isSaveDisabled}
-          >
-            保存する
-          </Button>
+          <TransactionForm
+            userInfo={userInfo}
+            categories={categories}
+            transactionData={transactionData}
+            isSaveDisabled={isSaveDisabled}
+            onAmountChange={handleAmountChange}
+            onDateChange={handleDateChange}
+            onCategoryChange={handleCategoryChange}
+            onPayerChange={handlePayerChange}
+            onShopNameChange={handleShopNameChange}
+            onMemoChange={handleMemoChange}
+            onSave={handleSave}
+            saveButtonText="更新する"
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/dashboard/ExpenseReport/TransactionDetailDialog.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/TransactionDetailDialog.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button.tsx";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import { CategoryList } from "@/components/dashboard/Transaction/CategoryList.tsx";
+import { Memo } from "@/components/dashboard/Transaction/Memo.tsx";
+import { PayerSelect } from "@/components/dashboard/Transaction/PayerSelect.tsx";
+import { RegisteredDate } from "@/components/dashboard/Transaction/RegisteredDate.tsx";
+import { ShopInfo } from "@/components/dashboard/Transaction/ShopInfo.tsx";
+import { Amount } from "@/components/dashboard/Transaction/Amount.tsx";
+import { Payment, CategoryData, TransactionData } from "@/types/transaction.ts";
+import { useAuth } from "@/contexts/AuthContext.tsx";
+import { getCategories } from "@/lib/api.ts";
+import { toast } from "sonner";
+import { format } from "date-fns";
+import { postTransaction } from "@/lib/api.ts";
+import { CategorySelection } from "@/types/transaction.ts";
+
+interface TransactionDetailDialogProps {
+  payment: Payment;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function TransactionDetailDialog({
+  payment,
+  isOpen,
+  onClose,
+}: TransactionDetailDialogProps) {
+  const [categories, setCategories] = useState<CategoryData>({});
+  const { userInfo, isAuth } = useAuth();
+  const [transactionData, setTransactionData] = useState<TransactionData>({
+    user: userInfo.user_id,
+    amount: 0,
+    date: new Date(),
+    category: null,
+    payer: userInfo.user_id,
+    shop_name: "",
+    memo: "",
+  });
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await getCategories();
+
+        if (response.status) {
+          setCategories(response.data);
+        }
+      } catch (err) {
+        toast.error("カテゴリーの取得に失敗しました", {
+          className: "!bg-red-600 !text-white !border-red-800",
+        });
+      }
+    };
+
+    if (isAuth) {
+      void fetchCategories();
+    }
+  }, []);
+
+  const handleAmountChange = (amount: number) => {
+    setTransactionData((prev) => ({ ...prev, amount }));
+  };
+
+  const handleDateChange = (date: Date) => {
+    setTransactionData((prev) => ({ ...prev, date }));
+  };
+
+  const handleCategoryChange = (category: CategorySelection | null) => {
+    setTransactionData((prev) => ({ ...prev, category }));
+  };
+
+  const handlePayerChange = (payer: string) => {
+    setTransactionData((prev) => ({ ...prev, payer }));
+  };
+
+  const handleShopNameChange = (shop_name: string) => {
+    setTransactionData((prev) => ({ ...prev, shop_name }));
+  };
+
+  const handleMemoChange = (memo: string) => {
+    setTransactionData((prev) => ({ ...prev, memo }));
+  };
+
+  const isSaveDisabled =
+    transactionData.amount <= 0 || transactionData.category === null;
+
+  const handleSave = async () => {
+    try {
+      const requestData = {
+        ...transactionData,
+        date: format(transactionData.date, "yyyy-MM-dd"),
+        category: parseInt(transactionData.category?.value || ""),
+      };
+
+      const response = await postTransaction(requestData);
+
+      if (response.status) {
+        toast.success("取引明細を保存しました", {
+          className: "!bg-yellow-600 !text-white !border-yellow-800",
+        });
+      } else {
+        toast.error("取引明細の保存に失敗しました", {
+          className: "!bg-red-600 !text-white !border-red-800",
+        });
+      }
+    } catch (error) {
+      toast.error("取引明細の保存に失敗しました", {
+        className: "!bg-red-600 !text-white !border-red-800",
+      });
+    } finally {
+      setTransactionData((prev) => ({
+        ...prev,
+        amount: 0,
+        date: new Date(),
+        category: null,
+        payer: userInfo.user_id,
+        shop_name: "",
+        memo: "",
+      }));
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>明細の編集</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-7">
+          {/* 金額 */}
+          <div className="flex justify-between items-end gap-2">
+            <Amount
+              amount={transactionData.amount}
+              onAmountChange={handleAmountChange}
+            />
+          </div>
+
+          <div className="flex items-center gap-4">
+            {/* 登録日 */}
+            <div className="w-1/2">
+              <RegisteredDate
+                date={transactionData.date}
+                onDateChange={handleDateChange}
+              />
+            </div>
+            {/* カテゴリー */}
+            <div className="w-1/2">
+              <CategoryList
+                categories={categories}
+                selected={transactionData.category}
+                onSelectionChange={handleCategoryChange}
+              />
+            </div>
+          </div>
+
+          {/* 支払者 */}
+          <div className="flex justify-between items-center">
+            <PayerSelect
+              userInfo={userInfo}
+              payer={transactionData.payer}
+              onPayerChange={handlePayerChange}
+            />
+          </div>
+          <div className="bg-gray-100 p-2 text-center">支出の詳細</div>
+
+          {/* お店の名前 */}
+          <div>
+            <ShopInfo
+              shop_name={transactionData.shop_name}
+              onShopNameChange={handleShopNameChange}
+            />
+          </div>
+
+          {/* メモ */}
+          <div>
+            <Memo memo={transactionData.memo} onMemoChange={handleMemoChange} />
+          </div>
+
+          <Button
+            className="w-full text-xl h-12"
+            onClick={handleSave}
+            disabled={isSaveDisabled}
+          >
+            保存する
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { formatDate } from "@/types/displayFormat.ts";
 import { updateTransactionData } from "@/types/transaction.ts";
-import { TransactionDetailDialog } from "./TransactionDetailDialog.tsx";
+import { TransactionDetailDialog } from "../Transaction/TransactionDetailDialog.tsx";
 
 export function TransactionRow({ category }: { category: any }) {
   const [selectedPayment, setSelectedPayment] =

--- a/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
@@ -1,12 +1,26 @@
+import { useState } from "react";
 import { formatDate } from "@/types/displayFormat.ts";
+import { Payment } from "@/types/transaction.ts";
+import { TransactionDetailDialog } from "./TransactionDetailDialog.tsx";
 
 export function TransactionRow({ category }: { category: any }) {
+  const [selectedPayment, setSelectedPayment] = useState<Payment | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleOpneDialog = (payment: Payment) => {
+    setSelectedPayment(payment);
+    setIsDialogOpen(true);
+  };
+
   return (
     <div className="space-y-1.5">
-      {category.payments.map((payment: any, paymentIndex: number) => (
+      {category.payments.map((payment: Payment, paymentIndex: number) => (
         <div
           key={`payment-${paymentIndex}`}
-          className="grid grid-cols-12 items-center p-1.5 rounded shadow-sm border-1 border-gray-50 hover:bg-gray-200 hover:border-gray-200 cursor-pointer"
+          onClick={() => {
+            handleOpneDialog(payment);
+          }}
+          className="grid grid-cols-12 items-center p-1.5 rounded shadow-sm border-1 border-gray-50 hover:bg-gray-200 hover:border-gray-200 hover:shadow-none cursor-pointer"
         >
           <span className="col-span-3 text-sm">
             {formatDate(payment.payment_date)}
@@ -19,6 +33,14 @@ export function TransactionRow({ category }: { category: any }) {
           </span>
         </div>
       ))}
+
+      {selectedPayment && (
+        <TransactionDetailDialog
+          payment={selectedPayment}
+          isOpen={isDialogOpen}
+          onClose={() => setIsDialogOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
@@ -1,38 +1,41 @@
 import { useState } from "react";
 import { formatDate } from "@/types/displayFormat.ts";
-import { Payment } from "@/types/transaction.ts";
+import { updateTransactionData } from "@/types/transaction.ts";
 import { TransactionDetailDialog } from "./TransactionDetailDialog.tsx";
 
 export function TransactionRow({ category }: { category: any }) {
-  const [selectedPayment, setSelectedPayment] = useState<Payment | null>(null);
+  const [selectedPayment, setSelectedPayment] =
+    useState<updateTransactionData | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const handleOpneDialog = (payment: Payment) => {
+  const handleOpneDialog = (payment: updateTransactionData) => {
     setSelectedPayment(payment);
     setIsDialogOpen(true);
   };
 
   return (
     <div className="space-y-1.5">
-      {category.payments.map((payment: Payment, paymentIndex: number) => (
-        <div
-          key={`payment-${paymentIndex}`}
-          onClick={() => {
-            handleOpneDialog(payment);
-          }}
-          className="grid grid-cols-12 items-center p-1.5 rounded shadow-sm border-1 border-gray-50 hover:bg-gray-200 hover:border-gray-200 hover:shadow-none cursor-pointer"
-        >
-          <span className="col-span-3 text-sm">
-            {formatDate(payment.payment_date)}
-          </span>
-          <span className="col-span-6 text-sm">
-            {payment.store_name ?? category.category_name}
-          </span>
-          <span className="col-span-3 font-medium text-right">
-            {payment.amount.toLocaleString()} 円
-          </span>
-        </div>
-      ))}
+      {category.payments.map(
+        (payment: updateTransactionData, paymentIndex: number) => (
+          <div
+            key={`payment-${paymentIndex}`}
+            onClick={() => {
+              handleOpneDialog(payment);
+            }}
+            className="grid grid-cols-12 items-center p-1.5 rounded shadow-sm border-1 border-gray-50 hover:bg-gray-200 hover:border-gray-200 hover:shadow-none cursor-pointer"
+          >
+            <span className="col-span-3 text-sm">
+              {formatDate(payment.payment_date)}
+            </span>
+            <span className="col-span-6 text-sm">
+              {payment.store_name ?? category.category_name}
+            </span>
+            <span className="col-span-3 font-medium text-right">
+              {payment.amount.toLocaleString()} 円
+            </span>
+          </div>
+        )
+      )}
 
       {selectedPayment && (
         <TransactionDetailDialog

--- a/frontend/src/components/dashboard/Transaction/CategoryList.tsx
+++ b/frontend/src/components/dashboard/Transaction/CategoryList.tsx
@@ -23,12 +23,13 @@ import type {
   CategoryListProps,
   CategorySelection,
 } from "@/types/transaction.ts";
+import { useCategory } from "@/contexts/CategoryContext.tsx";
 
 export function CategoryList({
-  categories,
   selected,
   onSelectionChange,
 }: CategoryListProps) {
+  const { categories, isCategoriesLoading } = useCategory();
   const [categoryOpen, setCategoryOpen] = useState(false);
 
   const clearSelections = () => {
@@ -47,79 +48,89 @@ export function CategoryList({
 
   return (
     <Popover open={categoryOpen} onOpenChange={setCategoryOpen}>
-      {/* カテゴリー選択ボタン */}
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          className="inline-flex w-full items-center justify-between gap-2 truncate"
-        >
-          <Folder />
-          {selected ? getSelectedCategoryName(categories, selected) : "未分類"}
-          <ChevronDown className="h-4 w-4" />
-        </Button>
-      </PopoverTrigger>
-
-      {/* カテゴリー選択ポップオーバー */}
-      <PopoverContent align="end" className="w-[300px] p-0">
-        <Tabs defaultValue={defaultTab} className="w-full">
-          {/* タブ上部：タブリスト */}
-          <div className="sticky top-0 z-10 bg-gray-200 rounded-t-md">
-            <TabsList className="grid w-full grid-cols-3 grid-rows-2 gap-1 p-1 bg-transparent h-auto">
-              {tabItems.map((t) => (
-                <TabsTrigger key={t.key} value={t.key} className="text-xs">
-                  {t.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </div>
-
-          {/* 各タブの内容 */}
-          {tabItems.map((t) => (
-            <TabsContent key={t.key} value={t.key} className="m-0">
-              <ScrollArea className="h-64 px-2 py-2">
-                <RadioGroup
-                  value={selected?.type === t.key ? selected.value : undefined}
-                  onValueChange={(val) => {
-                    onSelectionChange({ type: t.key, value: val });
-                    setCategoryOpen(false);
-                  }}
-                >
-                  <ul className="space-y-1">
-                    {categories[t.key]?.categories.map((category) => (
-                      <li key={category.id}>
-                        <label
-                          className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-accent"
-                          htmlFor={`${t.key}-${category.id}`}
-                        >
-                          <RadioGroupItem
-                            id={`${t.key}-${category.id}`}
-                            value={category.id.toString()}
-                          />
-                          <span className="flex-1 text-sm">
-                            {category.name}
-                          </span>
-                        </label>
-                      </li>
-                    ))}
-                  </ul>
-                </RadioGroup>
-              </ScrollArea>
-            </TabsContent>
-          ))}
-
-          {/* タブ下部：ボタン */}
-          <Separator />
-          <div className="flex items-center justify-between px-3 py-2">
+      {isCategoriesLoading ? (
+        <div className="text-sm text-gray-500">カテゴリーを読み込み中...</div>
+      ) : (
+        <>
+          {/* カテゴリー選択ボタン */}
+          <PopoverTrigger asChild>
             <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => void clearSelections()}
+              variant="outline"
+              className="inline-flex w-full items-center justify-between gap-2 truncate"
             >
-              クリア
+              <Folder />
+              {selected
+                ? getSelectedCategoryName(categories, selected)
+                : "未分類"}
+              <ChevronDown className="h-4 w-4" />
             </Button>
-          </div>
-        </Tabs>
-      </PopoverContent>
+          </PopoverTrigger>
+
+          {/* カテゴリー選択ポップオーバー */}
+          <PopoverContent align="end" className="w-[300px] p-0">
+            <Tabs defaultValue={defaultTab} className="w-full">
+              {/* タブ上部：タブリスト */}
+              <div className="sticky top-0 z-10 bg-gray-200 rounded-t-md">
+                <TabsList className="grid w-full grid-cols-3 grid-rows-2 gap-1 p-1 bg-transparent h-auto">
+                  {tabItems.map((t) => (
+                    <TabsTrigger key={t.key} value={t.key} className="text-xs">
+                      {t.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </div>
+
+              {/* 各タブの内容 */}
+              {tabItems.map((t) => (
+                <TabsContent key={t.key} value={t.key} className="m-0">
+                  <ScrollArea className="h-64 px-2 py-2">
+                    <RadioGroup
+                      value={
+                        selected?.type === t.key ? selected.value : undefined
+                      }
+                      onValueChange={(val) => {
+                        onSelectionChange({ type: t.key, value: val });
+                        setCategoryOpen(false);
+                      }}
+                    >
+                      <ul className="space-y-1">
+                        {categories[t.key]?.categories.map((category) => (
+                          <li key={category.id}>
+                            <label
+                              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-accent"
+                              htmlFor={`${t.key}-${category.id}`}
+                            >
+                              <RadioGroupItem
+                                id={`${t.key}-${category.id}`}
+                                value={category.id.toString()}
+                              />
+                              <span className="flex-1 text-sm">
+                                {category.name}
+                              </span>
+                            </label>
+                          </li>
+                        ))}
+                      </ul>
+                    </RadioGroup>
+                  </ScrollArea>
+                </TabsContent>
+              ))}
+
+              {/* タブ下部：ボタン */}
+              <Separator />
+              <div className="flex items-center justify-between px-3 py-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void clearSelections()}
+                >
+                  クリア
+                </Button>
+              </div>
+            </Tabs>
+          </PopoverContent>
+        </>
+      )}
     </Popover>
   );
 }

--- a/frontend/src/components/dashboard/Transaction/TransactionDetail.tsx
+++ b/frontend/src/components/dashboard/Transaction/TransactionDetail.tsx
@@ -1,126 +1,32 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { format } from "date-fns";
-import { CategoryList } from "@/components/dashboard/Transaction/CategoryList.tsx";
-import { Memo } from "@/components/dashboard/Transaction/Memo.tsx";
-import { PayerSelect } from "@/components/dashboard/Transaction/PayerSelect.tsx";
-import { RegisteredDate } from "@/components/dashboard/Transaction/RegisteredDate.tsx";
-import { ShopInfo } from "@/components/dashboard/Transaction/ShopInfo.tsx";
-import { Button } from "@/components/ui/button.tsx";
+import { useTransactionForm } from "@/hooks/useTransactionForm.tsx";
+import { TransactionForm } from "./TransactionForm.tsx";
+import { useAuth } from "@/contexts/AuthContext.tsx";
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.tsx";
-import { getCategories } from "@/lib/api.ts";
-import type {
-  TransactionData,
-  CategoryData,
-  CategorySelection,
-} from "@/types/transaction.ts";
-import { Amount } from "./Amount.tsx";
-import { postTransaction } from "@/lib/api.ts";
-import { toast } from "sonner";
-import { useAuth } from "@/contexts/AuthContext.tsx";
 
 export function TransactionDetail() {
-  const [_error, _setError] = useState<string | null>(null);
-  const [categories, setCategories] = useState<CategoryData>({});
-  const { userInfo, isAuth } = useAuth();
-  const [transactionData, setTransactionData] = useState<TransactionData>({
-    user: userInfo.user_id,
-    amount: 0,
-    date: new Date(),
-    category: null,
-    payer: userInfo.user_id,
-    shop_name: "",
-    memo: "",
+  const { userInfo } = useAuth();
+  const {
+    categories,
+    transactionData,
+    isSaveDisabled,
+    handleAmountChange,
+    handleDateChange,
+    handleCategoryChange,
+    handlePayerChange,
+    handleShopNameChange,
+    handleMemoChange,
+    handleSave,
+  } = useTransactionForm({
+    transactionPatch: {},
+    onSaveSuccess: () => {},
   });
-
-  useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        const response = await getCategories();
-
-        if (response.status) {
-          setCategories(response.data);
-        }
-      } catch (err) {
-        toast.error("カテゴリーの取得に失敗しました", {
-          className: "!bg-red-600 !text-white !border-red-800",
-        });
-      }
-    };
-
-    if (isAuth) {
-      void fetchCategories();
-    }
-  }, []);
-
-  const handleAmountChange = (amount: number) => {
-    setTransactionData((prev) => ({ ...prev, amount }));
-  };
-
-  const handleDateChange = (date: Date) => {
-    setTransactionData((prev) => ({ ...prev, date }));
-  };
-
-  const handleCategoryChange = (category: CategorySelection | null) => {
-    setTransactionData((prev) => ({ ...prev, category }));
-  };
-
-  const handlePayerChange = (payer: string) => {
-    setTransactionData((prev) => ({ ...prev, payer }));
-  };
-
-  const handleShopNameChange = (shop_name: string) => {
-    setTransactionData((prev) => ({ ...prev, shop_name }));
-  };
-
-  const handleMemoChange = (memo: string) => {
-    setTransactionData((prev) => ({ ...prev, memo }));
-  };
-
-  const isSaveDisabled =
-    transactionData.amount <= 0 || transactionData.category === null;
-
-  const handleSave = async () => {
-    try {
-      const requestData = {
-        ...transactionData,
-        date: format(transactionData.date, "yyyy-MM-dd"),
-        category: parseInt(transactionData.category?.value || ""),
-      };
-
-      const response = await postTransaction(requestData);
-
-      if (response.status) {
-        toast.success("取引明細を保存しました", {
-          className: "!bg-yellow-600 !text-white !border-yellow-800",
-        });
-      } else {
-        toast.error("取引明細の保存に失敗しました", {
-          className: "!bg-red-600 !text-white !border-red-800",
-        });
-      }
-    } catch (error) {
-      toast.error("取引明細の保存に失敗しました", {
-        className: "!bg-red-600 !text-white !border-red-800",
-      });
-    } finally {
-      setTransactionData((prev) => ({
-        ...prev,
-        amount: 0,
-        date: new Date(),
-        category: null,
-        payer: userInfo.user_id,
-        shop_name: "",
-        memo: "",
-      }));
-    }
-  };
 
   return (
     <div className="bg-white overflow-hidden shadow rounded-lg">
@@ -129,62 +35,20 @@ export function TransactionDetail() {
           <CardTitle>{userInfo.name} の取引明細</CardTitle>
         </CardHeader>
         <CardContent className="space-y-7">
-          {/* 金額 */}
-          <div className="flex justify-between items-end gap-2">
-            <Amount
-              amount={transactionData.amount}
-              onAmountChange={handleAmountChange}
-            />
-          </div>
-
-          <div className="flex items-center gap-4">
-            {/* 登録日 */}
-            <div className="w-1/2">
-              <RegisteredDate
-                date={transactionData.date}
-                onDateChange={handleDateChange}
-              />
-            </div>
-            {/* カテゴリー */}
-            <div className="w-1/2">
-              <CategoryList
-                categories={categories}
-                selected={transactionData.category}
-                onSelectionChange={handleCategoryChange}
-              />
-            </div>
-          </div>
-
-          {/* 支払者 */}
-          <div className="flex justify-between items-center">
-            <PayerSelect
-              userInfo={userInfo}
-              payer={transactionData.payer}
-              onPayerChange={handlePayerChange}
-            />
-          </div>
-          <div className="bg-gray-100 p-2 text-center">支出の詳細</div>
-
-          {/* お店の名前 */}
-          <div>
-            <ShopInfo
-              shop_name={transactionData.shop_name}
-              onShopNameChange={handleShopNameChange}
-            />
-          </div>
-
-          {/* メモ */}
-          <div>
-            <Memo memo={transactionData.memo} onMemoChange={handleMemoChange} />
-          </div>
-
-          <Button
-            className="w-full text-xl h-12"
-            onClick={handleSave}
-            disabled={isSaveDisabled}
-          >
-            保存する
-          </Button>
+          <TransactionForm
+            userInfo={userInfo}
+            categories={categories}
+            transactionData={transactionData}
+            isSaveDisabled={isSaveDisabled}
+            onAmountChange={handleAmountChange}
+            onDateChange={handleDateChange}
+            onCategoryChange={handleCategoryChange}
+            onPayerChange={handlePayerChange}
+            onShopNameChange={handleShopNameChange}
+            onMemoChange={handleMemoChange}
+            onSave={handleSave}
+            saveButtonText="保存する"
+          />
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/dashboard/Transaction/TransactionDetail.tsx
+++ b/frontend/src/components/dashboard/Transaction/TransactionDetail.tsx
@@ -13,7 +13,6 @@ import {
 export function TransactionDetail() {
   const { userInfo } = useAuth();
   const {
-    categories,
     transactionData,
     isSaveDisabled,
     handleAmountChange,
@@ -37,7 +36,6 @@ export function TransactionDetail() {
         <CardContent className="space-y-7">
           <TransactionForm
             userInfo={userInfo}
-            categories={categories}
             transactionData={transactionData}
             isSaveDisabled={isSaveDisabled}
             onAmountChange={handleAmountChange}

--- a/frontend/src/components/dashboard/Transaction/TransactionDetailDialog.tsx
+++ b/frontend/src/components/dashboard/Transaction/TransactionDetailDialog.tsx
@@ -7,7 +7,7 @@ import {
 import { updateTransactionData } from "@/types/transaction.ts";
 import { useAuth } from "@/contexts/AuthContext.tsx";
 import { useTransactionForm } from "@/hooks/useTransactionForm.tsx";
-import { TransactionForm } from "../Transaction/TransactionForm";
+import { TransactionForm } from "./TransactionForm";
 
 interface TransactionDetailDialogProps {
   payment: updateTransactionData;
@@ -22,7 +22,6 @@ export function TransactionDetailDialog({
 }: TransactionDetailDialogProps) {
   const { userInfo } = useAuth();
   const {
-    categories,
     transactionData,
     isSaveDisabled,
     handleAmountChange,
@@ -46,7 +45,6 @@ export function TransactionDetailDialog({
         <div className="space-y-7">
           <TransactionForm
             userInfo={userInfo}
-            categories={categories}
             transactionData={transactionData}
             isSaveDisabled={isSaveDisabled}
             onAmountChange={handleAmountChange}

--- a/frontend/src/components/dashboard/Transaction/TransactionForm.tsx
+++ b/frontend/src/components/dashboard/Transaction/TransactionForm.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { CategoryList } from "@/components/dashboard/Transaction/CategoryList.tsx";
+import { Memo } from "@/components/dashboard/Transaction/Memo.tsx";
+import { PayerSelect } from "@/components/dashboard/Transaction/PayerSelect.tsx";
+import { RegisteredDate } from "@/components/dashboard/Transaction/RegisteredDate.tsx";
+import { ShopInfo } from "@/components/dashboard/Transaction/ShopInfo.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { CardContent } from "@/components/ui/card.tsx";
+import type {
+  TransactionData,
+  CategoryData,
+  CategorySelection,
+} from "@/types/transaction.ts";
+import { Amount } from "./Amount.tsx";
+
+interface TransactionFormProps {
+  // data
+  userInfo: { user_id: string; name: string };
+  categories: CategoryData;
+  transactionData: TransactionData;
+  isSaveDisabled: boolean;
+  saveButtonText: string; // ボタンのテキスト
+  // handler
+  onAmountChange: (amount: number) => void;
+  onDateChange: (date: Date) => void;
+  onCategoryChange: (category: CategorySelection | null) => void;
+  onPayerChange: (payer: string) => void;
+  onShopNameChange: (shop_name: string) => void;
+  onMemoChange: (memo: string) => void;
+  onSave: () => void;
+}
+
+export function TransactionForm({
+  userInfo,
+  categories,
+  transactionData,
+  isSaveDisabled,
+  onAmountChange,
+  onDateChange,
+  onCategoryChange,
+  onPayerChange,
+  onShopNameChange,
+  onMemoChange,
+  onSave,
+  saveButtonText,
+}: TransactionFormProps) {
+  return (
+    <>
+      <CardContent className="space-y-7">
+        {/* 金額 */}
+        <div className="flex justify-between items-end gap-2">
+          <Amount
+            amount={transactionData.amount}
+            onAmountChange={onAmountChange}
+          />
+        </div>
+
+        <div className="flex items-center gap-4">
+          {/* 登録日 */}
+          <div className="w-1/2">
+            <RegisteredDate
+              date={transactionData.date}
+              onDateChange={onDateChange}
+            />
+          </div>
+          {/* カテゴリー */}
+          <div className="w-1/2">
+            <CategoryList
+              categories={categories}
+              selected={transactionData.category}
+              onSelectionChange={onCategoryChange}
+            />
+          </div>
+        </div>
+
+        {/* 支払者 */}
+        <div className="flex justify-between items-center">
+          <PayerSelect
+            userInfo={userInfo}
+            payer={transactionData.payer}
+            onPayerChange={onPayerChange}
+          />
+        </div>
+        <div className="bg-gray-100 p-2 text-center">支出の詳細</div>
+
+        {/* お店の名前 */}
+        <div>
+          <ShopInfo
+            shop_name={transactionData.shop_name}
+            onShopNameChange={onShopNameChange}
+          />
+        </div>
+
+        {/* メモ */}
+        <div>
+          <Memo memo={transactionData.memo} onMemoChange={onMemoChange} />
+        </div>
+
+        <Button
+          className="w-full text-xl h-12"
+          onClick={onSave}
+          disabled={isSaveDisabled}
+        >
+          {saveButtonText}
+        </Button>
+      </CardContent>
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/Transaction/TransactionForm.tsx
+++ b/frontend/src/components/dashboard/Transaction/TransactionForm.tsx
@@ -17,7 +17,6 @@ import { Amount } from "./Amount.tsx";
 interface TransactionFormProps {
   // data
   userInfo: { user_id: string; name: string };
-  categories: CategoryData;
   transactionData: TransactionData;
   isSaveDisabled: boolean;
   saveButtonText: string; // ボタンのテキスト
@@ -33,7 +32,6 @@ interface TransactionFormProps {
 
 export function TransactionForm({
   userInfo,
-  categories,
   transactionData,
   isSaveDisabled,
   onAmountChange,
@@ -67,7 +65,6 @@ export function TransactionForm({
           {/* カテゴリー */}
           <div className="w-1/2">
             <CategoryList
-              categories={categories}
               selected={transactionData.category}
               onSelectionChange={onCategoryChange}
             />

--- a/frontend/src/contexts/CategoryContext.tsx
+++ b/frontend/src/contexts/CategoryContext.tsx
@@ -1,0 +1,62 @@
+import {
+  useState,
+  useEffect,
+  useContext,
+  createContext,
+  ReactNode,
+} from "react";
+import { useAuth } from "@/contexts/AuthContext.tsx";
+import { getCategories } from "@/lib/api.ts";
+import { CategoryData } from "@/types/transaction.ts";
+import { toast } from "sonner";
+
+interface CategoryContextType {
+  categories: CategoryData;
+  isCategoriesLoading: boolean;
+}
+
+const CategoryContext = createContext<CategoryContextType | undefined>(
+  undefined
+);
+
+export const CategoryProvider = ({ children }: { children: ReactNode }) => {
+  const { isAuth } = useAuth();
+  const [categories, setCategories] = useState<CategoryData>({});
+  const [isCategoriesLoading, setIsCategoriesLoading] = useState(false);
+  const fetchCategories = async () => {
+    if (!isAuth) return;
+
+    setIsCategoriesLoading(true);
+    try {
+      const response = await getCategories();
+
+      if (response.status) {
+        setCategories(response.data);
+      }
+    } catch (err) {
+      toast.error("カテゴリーの取得に失敗しました", {
+        className: "!bg-red-600 !text-white !border-red-800",
+      });
+    } finally {
+      setIsCategoriesLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchCategories();
+  }, [isAuth]);
+
+  return (
+    <CategoryContext.Provider value={{ categories, isCategoriesLoading }}>
+      {children}
+    </CategoryContext.Provider>
+  );
+};
+
+export function useCategory() {
+  const context = useContext(CategoryContext);
+  if (context === undefined) {
+    throw new Error("useCategory must be used within a CategoryProvider");
+  }
+  return context;
+}

--- a/frontend/src/hooks/useTransactionForm.tsx
+++ b/frontend/src/hooks/useTransactionForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { format } from "date-fns";
 import { useAuth } from "@/contexts/AuthContext.tsx";
+import { useCategory } from "@/contexts/CategoryContext.tsx";
 import {
   TransactionData,
   CategoryData,
@@ -19,8 +20,8 @@ export const useTransactionForm = ({
   transactionPatch,
   onSaveSuccess,
 }: UseTransactionFormProps) => {
-  const { userInfo, isAuth } = useAuth();
-  const [categories, setCategories] = useState<CategoryData>({});
+  const { userInfo } = useAuth();
+  const { categories, isCategoriesLoading } = useCategory();
   const [transactionData, setTransactionData] = useState<TransactionData>(
     transactionPatch
       ? {
@@ -50,26 +51,6 @@ export const useTransactionForm = ({
           memo: "",
         }
   );
-
-  useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        const response = await getCategories();
-
-        if (response.status) {
-          setCategories(response.data);
-        }
-      } catch (err) {
-        toast.error("カテゴリーの取得に失敗しました", {
-          className: "!bg-red-600 !text-white !border-red-800",
-        });
-      }
-    };
-
-    if (isAuth) {
-      void fetchCategories();
-    }
-  }, []);
 
   const handleAmountChange = (amount: number) => {
     setTransactionData((prev) => ({ ...prev, amount }));
@@ -141,6 +122,7 @@ export const useTransactionForm = ({
 
   return {
     categories,
+    isCategoriesLoading,
     transactionData,
     isSaveDisabled,
     handleAmountChange,

--- a/frontend/src/hooks/useTransactionForm.tsx
+++ b/frontend/src/hooks/useTransactionForm.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from "react";
+import { format } from "date-fns";
+import { useAuth } from "@/contexts/AuthContext.tsx";
+import {
+  TransactionData,
+  CategoryData,
+  CategorySelection,
+  updateTransactionData,
+} from "@/types/transaction.tsx";
+import { getCategories, postTransaction } from "@/lib/api.ts";
+import { toast } from "sonner";
+
+interface UseTransactionFormProps {
+  transactionPatch: Partial<updateTransactionData>;
+  onSaveSuccess: () => void;
+}
+
+export const useTransactionForm = ({
+  transactionPatch,
+  onSaveSuccess,
+}: UseTransactionFormProps) => {
+  const { userInfo, isAuth } = useAuth();
+  const [categories, setCategories] = useState<CategoryData>({});
+  const [transactionData, setTransactionData] = useState<TransactionData>(
+    transactionPatch
+      ? {
+          user: userInfo.user_id,
+          amount: transactionPatch.amount || 0,
+          date: transactionPatch.payment_date
+            ? new Date(transactionPatch.payment_date)
+            : new Date(),
+          category: transactionPatch.category_id
+            ? {
+                type: "category",
+                value: transactionPatch.category_id.toString(),
+              }
+            : null,
+          payer:
+            transactionPatch.paid_by_user_id?.toString() || userInfo.user_id,
+          shop_name: transactionPatch.store_name || "",
+          memo: transactionPatch.note || "",
+        }
+      : {
+          user: userInfo.user_id,
+          amount: 0,
+          date: new Date(),
+          category: null,
+          payer: userInfo.user_id,
+          shop_name: "",
+          memo: "",
+        }
+  );
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await getCategories();
+
+        if (response.status) {
+          setCategories(response.data);
+        }
+      } catch (err) {
+        toast.error("カテゴリーの取得に失敗しました", {
+          className: "!bg-red-600 !text-white !border-red-800",
+        });
+      }
+    };
+
+    if (isAuth) {
+      void fetchCategories();
+    }
+  }, []);
+
+  const handleAmountChange = (amount: number) => {
+    setTransactionData((prev) => ({ ...prev, amount }));
+  };
+
+  const handleDateChange = (date: Date) => {
+    setTransactionData((prev) => ({ ...prev, date }));
+  };
+
+  const handleCategoryChange = (category: CategorySelection | null) => {
+    setTransactionData((prev) => ({ ...prev, category }));
+  };
+
+  const handlePayerChange = (payer: string) => {
+    setTransactionData((prev) => ({ ...prev, payer }));
+  };
+
+  const handleShopNameChange = (shop_name: string) => {
+    setTransactionData((prev) => ({ ...prev, shop_name }));
+  };
+
+  const handleMemoChange = (memo: string) => {
+    setTransactionData((prev) => ({ ...prev, memo }));
+  };
+
+  const handleSave = async () => {
+    try {
+      const requestData = {
+        ...transactionData,
+        date: format(transactionData.date, "yyyy-MM-dd"),
+        category: parseInt(transactionData.category?.value || ""),
+      };
+
+      const response = await postTransaction(requestData);
+
+      if (response.status) {
+        toast.success("取引明細を保存しました", {
+          className: "!bg-yellow-600 !text-white !border-yellow-800",
+        });
+        onSaveSuccess();
+      } else {
+        toast.error("取引明細の保存に失敗しました", {
+          className: "!bg-red-600 !text-white !border-red-800",
+        });
+      }
+    } catch (error) {
+      toast.error("取引明細の保存に失敗しました", {
+        className: "!bg-red-600 !text-white !border-red-800",
+      });
+    } finally {
+      resetForm();
+    }
+  };
+
+  const resetForm = () => {
+    setTransactionData({
+      user: userInfo.user_id,
+      amount: 0,
+      date: new Date(),
+      category: null,
+      payer: userInfo.user_id,
+      shop_name: "",
+      memo: "",
+    });
+  };
+
+  const isSaveDisabled =
+    transactionData.amount <= 0 || transactionData.category === null;
+
+  return {
+    categories,
+    transactionData,
+    isSaveDisabled,
+    handleAmountChange,
+    handleDateChange,
+    handleCategoryChange,
+    handlePayerChange,
+    handleShopNameChange,
+    handleMemoChange,
+    handleSave,
+    resetForm,
+  };
+};

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -52,7 +52,6 @@ export interface CategorySelection {
 }
 
 export interface CategoryListProps {
-  categories: CategoryData;
   selected: CategorySelection | null;
   onSelectionChange: (selected: CategorySelection | null) => void;
 }

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -10,7 +10,7 @@ export interface TransactionData {
 }
 
 // 編集用の取引明細の型定義
-export interface Payment {
+export interface updateTransactionData {
   id: number;
   amount: number;
   category_id: number;

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -1,5 +1,4 @@
 // 取引明細の型定義
-
 export interface TransactionData {
   user: string;
   amount: number;
@@ -8,6 +7,18 @@ export interface TransactionData {
   payer: string;
   shop_name: string;
   memo: string;
+}
+
+// 編集用の取引明細の型定義
+export interface Payment {
+  id: number;
+  amount: number;
+  category_id: number;
+  payment_date: string;
+  paid_by_user_id: number;
+  couple_id: number | null;
+  store_name: string | null;
+  note: string | null;
 }
 
 // API送信用の型（日付は文字列）
@@ -22,7 +33,6 @@ export interface TransactionRequestData {
 }
 
 // カテゴリー関連の型定義
-
 export interface Category {
   id: number;
   code: string;


### PR DESCRIPTION
以下の処理を実装
・明細編集用のモーダル画面作成
・カスタムホックを使用して、明細記録のフォームを統一
・カテゴリの取得をusecontextで一括取得し、グローバル管理できるよう修正