### PR TITLE
パートナー登録解除時にユーザーモードをaloneに変更

### DIFF
--- a/backend/app/Http/Controllers/Api/SettingController.php
+++ b/backend/app/Http/Controllers/Api/SettingController.php
@@ -95,7 +95,7 @@ class SettingController extends Controller
         $user = $request->attributes->get('auth_user');
         $coupleId = $user->couple_id;
         $partner = User::where('couple_id', $coupleId)
-            ->where('id', '! =', $user->id)
+            ->where('id', '!=', $user->id)
             ->first();
 
         if (! $partner) {

--- a/frontend/src/components/account/UserInfoEdit.tsx
+++ b/frontend/src/components/account/UserInfoEdit.tsx
@@ -20,10 +20,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip.tsx";
 import { useAuth } from "@/contexts/AuthContext.tsx";
+import { useViewMode } from "@/contexts/ViewModeContext.tsx";
 import { useSettingForm } from "@/hooks/useSettingForm.tsx";
 import { postPartnerReset } from "@/lib/api.ts";
 
 export function UserInfoEdit() {
+  const { refreshUserInfo } = useAuth();
+  const { setUser } = useViewMode();
   const {
     userInfo,
     userName,
@@ -33,7 +36,6 @@ export function UserInfoEdit() {
     handleUserInfoSave,
   } = useSettingForm();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const { refreshUserInfo } = useAuth();
 
   const handleOpenResultDialog = () => {
     setIsDialogOpen(true);
@@ -49,9 +51,10 @@ export function UserInfoEdit() {
 
       if (response.status) {
         await refreshUserInfo();
-        toast.success("パートナーを解除しました");
+        setUser("alone");
         handlePartnerId("");
         setIsDialogOpen(false);
+        toast.success("パートナーを解除しました");
       } else {
         toast.error(response.message, {
           className: "!bg-red-600 !text-white !border-red-800",


### PR DESCRIPTION
ユーザーモードをcommonに設定したままパートナー登録を解除すると、システム上のユーザーモードがcommonのままになるバグが発生していた。
パートナー解除時にユーザーモードを強制的にaloneにする設定を追加。