### PR TITLE
非有効化の条件にユーザーモードがaloneの時を追加

### DIFF
--- a/frontend/src/components/dashboard/Transaction/PayerSelect.tsx
+++ b/frontend/src/components/dashboard/Transaction/PayerSelect.tsx
@@ -1,11 +1,13 @@
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
 import type { PayerSelectProps } from "@/types/transaction.ts";
+import { useViewMode } from "@/contexts/ViewModeContext.tsx";
 
 export function PayerSelect({
   userInfo,
   payer,
   onPayerChange,
 }: PayerSelectProps) {
+  const { user } = useViewMode();
   // 選択された支払者を取得
   const getSelectedPayer = () => {
     if (payer === userInfo.id) {
@@ -39,11 +41,10 @@ export function PayerSelect({
           {userInfo.name}
         </ToggleGroupItem>
         <ToggleGroupItem
-          disabled={!userInfo.couple_id}
+          disabled={user === "alone" || !userInfo.couple_id}
           className={[
             "px-6 py-2 text-sm outline-none transition",
-            // パートナーがいない場合は無効化
-            !userInfo.couple_id
+            user === "alone" || !userInfo.couple_id
               ? "bg-gray-700 text-black cursor-not-allowed"
               : getSelectedPayer() === userInfo.couple_id
                 ? "!bg-cyan-600 !text-white"


### PR DESCRIPTION
ユーザーモードが「個人」の際に、パートナーのトグルが非有効化されるように変更
表示とdisabledの両方を変更した

Close #79 