### PR TITLE
支出管理表の明細に設定した予算が表示されるように修正

### DIFF
--- a/backend/app/Models/Category.php
+++ b/backend/app/Models/Category.php
@@ -24,4 +24,9 @@ class Category extends Model
     {
         return $this->hasMany(Payment::class, 'category_id', 'id');
     }
+
+    public function budget()
+    {
+        return $this->hasMany(Budget::class, 'category_id', 'id');
+    }
 }

--- a/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/TransactionRow.tsx
@@ -36,12 +36,19 @@ export function TransactionRow({
     setSelectedPayment(null);
   }, []); // 依存関係なし
 
+  console.log(category);
+
   return (
     <Accordion type="single" collapsible className="w-full">
       <AccordionItem value={category.category_name} className="space-y-1.5">
         <AccordionTrigger className="grid grid-cols-12 items-center p-1.5 rounded shadow-sm border-1 border-gray-50 hover:bg-gray-100 hover:border-blue-400 hover:shadow-none hover:no-underline cursor-pointer">
           <span className="col-span-4">{category.category_name}</span>
-          <span className="col-span-7 text-right">
+          <span className="col-span-4 text-right text-gray-500 text-xs">
+            {category.budget_amount !== null
+              ? `予算 ${category.budget_amount?.toLocaleString()} 円`
+              : ``}
+          </span>
+          <span className="col-span-3 text-right">
             {totalAmount.toLocaleString()} 円
           </span>
         </AccordionTrigger>

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -65,6 +65,7 @@ export interface CategoryGroupData {
 // 支出管理表の型定義（カテゴリと取引明細詳細）
 export interface CategoryWithPayments {
   category_name: string;
+  budget_amount: number | null;
   payments: SavedTransactionData[];
 }
 


### PR DESCRIPTION
支出管理表のカテゴリー明細（TransactionRow）に予算を表示させるように修正
予算の値は支出管理表に表示するデータを取得するタイミングで一緒に取得

以下の条件を満たす明細に予算を表示させている
- 月次の予算設定をしているもの
- サブスクリプションではないもの

懸念していたAPIで取得するデータの重複だが、杞憂であった。
支出管理表はyearとmonthでソートしたデータを取得
予実管理表はyearでソートしtデータを取得
この観点からデータの使いまわしは難しいため、適切な分離ができていると判断した。

Close #88 