### PR TITLE
支出管理表の予算と実績に関する表示ルールの変更

### DIFF
--- a/backend/app/Traits/ReportDataTrait.php
+++ b/backend/app/Traits/ReportDataTrait.php
@@ -65,11 +65,11 @@ trait ReportDataTrait
 
             // 予算データを取得
             $budget = $category->budget->first();
-            
+
             // period_typeに応じて予算金額を計算
             if ($budget) {
-                $budgetAmount = $budget->period_type === 'monthly' 
-                    ? $budget->amount 
+                $budgetAmount = $budget->period_type === 'monthly'
+                    ? $budget->amount
                     : ceil($budget->amount / 12);
             } else {
                 $budgetAmount = null;

--- a/frontend/src/components/dashboard/SpendingManagementPage.tsx
+++ b/frontend/src/components/dashboard/SpendingManagementPage.tsx
@@ -29,8 +29,6 @@ export function SpendingManagementPage({
     isAuth
   );
 
-  console.log(expenseReport);
-
   const handleUpdte = () => {
     void expenseMutate();
     void budgetUsageMutate();


### PR DESCRIPTION
明細を表示するルールを以下の通りに変更
- 予算設定前
  - 予算の記述を表示させない
- 予算設定後
  - 予算が1以上、実績が0の際は予算のみを表示させる
  - 予算が1以上、実績が1以上の際は予算と実績の両方を表示させる
  - 予算が0、実績が0の場合は支出管理表に表示されない
  - 予算が0、実績が1以上の場合は予算と実績の両方を表示させる