### PR TITLE
予算と実績の合計を取得し 差分を表示する機能を追加

### DIFF
--- a/backend/app/Http/Controllers/Api/ExpenseReportController.php
+++ b/backend/app/Http/Controllers/Api/ExpenseReportController.php
@@ -70,6 +70,8 @@ class ExpenseReportController extends Controller
             }
         }
 
+        $sortedByCategoryData = $this->getTotalExpenseData($sortedByCategoryData);
+
         return response()->json([
             'status' => true,
             'data' => $sortedByCategoryData,

--- a/frontend/src/components/dashboard/ExpenseReport/ExpenseTable.tsx
+++ b/frontend/src/components/dashboard/ExpenseReport/ExpenseTable.tsx
@@ -4,10 +4,8 @@ import {
   Card,
   CardContent,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card.tsx";
 import { YearMonthSelector } from "@/components/ui/YearMonthSelector.tsx";
-import { useAuth } from "@/contexts/AuthContext.tsx";
 import type { ExpenseTableProps } from "@/types/expense.ts";
 
 export function ExpenseTable({
@@ -18,13 +16,42 @@ export function ExpenseTable({
   handleUpdte,
   monthlyAndYearlyDateSelector,
 }: ExpenseTableProps) {
-  const { userInfo } = useAuth();
-
   return (
     <div className="bg-white overflow-hidden shadow rounded-lg">
       <Card>
         <CardHeader className="flex justify-between">
-          <CardTitle>{userInfo?.name} の支出管理表</CardTitle>
+          {expenseReport?.data && (
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-4 bg-stone-200 px-3 py-1 rounded">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm text-gray-500">予算</p>
+                  <p className="text-lg">
+                    ¥{expenseReport.data.totalBudget?.toLocaleString()}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm text-gray-500">支出</p>
+                  <p className="text-lg">
+                    ¥{expenseReport.data.totalPayment?.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+              <div
+                className={`px-3 py-1 rounded ${
+                  (expenseReport.data.defference ?? 0) >= 0
+                    ? "bg-blue-200"
+                    : "bg-red-200"
+                }`}
+              >
+                <p className="text-lg">
+                  残り{" "}
+                  <strong>
+                    ¥{expenseReport.data.defference?.toLocaleString()}
+                  </strong>
+                </p>
+              </div>
+            </div>
+          )}
           <YearMonthSelector
             {...monthlyAndYearlyDateSelector}
             showMonth={true}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -12,7 +12,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -20,12 +20,12 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-center gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -35,7 +35,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,7 +45,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -58,7 +58,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -60,6 +60,9 @@ export interface ExpenseReportData {
   occasional_variable_cost?: CategoryGroupData;
   luxury_consumption_cost?: CategoryGroupData;
   savings_investment_cost?: CategoryGroupData;
+  totalBudget?: number;
+  totalPayment?: number;
+  defference?: number;
 }
 
 // 支出管理表の型定義（カテゴリーグループとカテゴリ詳細）


### PR DESCRIPTION
支出管理表にて、予算と実績の合計値を取得しその差分を表示する機能を実装。
既存で取得していたデータをコレクションに変換してsumで合計値を取得。

Close #98 