### PR TITLE
パートナー設定時に接続するAPIを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,171 @@
-#　起動方法
+# 支出わけっと
 
-## コンテナの立ち上げ
+スキル向上を目的に、家計管理アプリケーション **支出わけっと** を作成しました。
 
-```bash
-cd inrfa
-docker compose up -d --build
-```
+これはシングルページアプリケーション (SPA) として作成しており、以下の技術を採用しております。
+フロントエンド：**TypeScript / Next.js**
+バックエンド：**PHP / Laravel**
+インフラ：**S3+CloudFront（静的サイト） / ECS（API）**
 
-## バックエンドのコンテナに入る
+開発環境には Docker を用いており、フロントエンドとバックエンドを分離したモノレポ構成で開発しています。
 
-```bash
-docker compose exec backend bash
-```
+# 目次
 
-## Seed ファイルの実行
+1. [サービスの概要](#1サービスの概要)
+2. [機能一覧](#2機能一覧)
+3. [操作画面](#3画面操作)
+4. [技術スタック](#4技術スタック)
+5. [アプリ開発の振り返り](#5アプリ開発の振り返り)
+6. [今後の展望](#6今後の展望)
 
-```docker
-php artisan db:seed
-```
+## 1.サービスの概要
 
-ページにアクセス
-http://localhost:3000/
+支出管理表と家計簿の機能を統合し、予算設定から実績管理、可視化まで一括で行える家計管理アプリケーションです。<br >
+ユーザーモード（個人/共有）を切り替えることで、個人の家計とパートナー都の家計を柔軟に管理できます。
 
-# コンテナ操作
+👩 家計簿をつけてはいるけど活用できていない<br >
+🧑 恋人/夫婦の支払いの分担・清算に困っている<br >
+こんな困りごとを解決するために作成したアプリケーションです。
 
-```be
-docker compose exec -it backend bash
-```
+URL：https://waketto.com/
 
-```fe
-docker compose exec -it frontend bash
-```
+## 2.機能一覧
 
-# ESLint を動かす
+- 認証
 
-```bash
-# 全ファイルのチェック
-pnpm eslint
+  - ログイン / ログアウト
+    - AWS Cognito による認証
+    - JWT トークンベース
+    - トークンの自動リフレッシュ（セッション維持）
+  - ユーザー登録
+    - メールアドレスとパスワードで登録
+    - 確認コードによるメールアドレス検証
 
-# 全ファイルの自動修正
-pnpm eslint --fix
-```
+- アカウント管理
 
-こんな使い方もできる
+  - ユーザー名の変更
+  - パートナー連携 / 解除
+  - パスワードの変更 / リセット
+  - メールアドレスの変更
+  - アカウント削除
 
-```bash
-# 特定のフォルダ内のみチェック
-pnpm eslint src/
+- ユーザーモード切り替え
 
-# 特定ファイルのみチェック
-pnpm eslint src/components/Button.tsx
-```
+  - 個人モード
+    - ログインユーザーが登録した明細のみ表示
+  - 共有モード
+    - ログインユーザーとそのパートナーが登録した明細が表示
+    - 支払い担当者を記録し、分担を可視化
 
-# 使用技術
+- 明細管理
 
-認証
-OIDC プロバイダ：Cognito
-フロントエンド：Amplify
+  - 明細の登録 / 更新 / 削除
+  - ファイナンスモード切り替えによる表示変更
+  - 明細の表示（月次ビュー）
+
+    - テーブル形式での明細一覧表示
+    - カテゴリー別円グラフによる支出割合の可視化
+    - 月間合計金額の表示
+
+  - 明細の表示（年次ビュー）
+
+    - カテゴリー別・月別の支出推移を棒グラフで可視
+
+- 予算管理
+
+  - カテゴリー別に予算の登録 / 更新
+  - 月別予算消化状況の表示
+  - 残予算の自動計算
+
+- サブスクリプション管理
+
+  - サブスクリプション登録 / 更新 / 削除
+  - 登録したサブスクリプションを月次明細に自動反映
+
+## 3.画面
+
+### 3-1.新規登録 / ログインの画面
+
+### 3-2.支出管理 / 家計簿の画面
+
+### 3-3.予算 / サブスクリプションの設定画面
+
+### 3-4.アカウントの設定画面
+
+## 4.技術スタック
+
+### 4-1.使用技術一覧
+
+#### フロントエンド
+
+フロントエンドの開発言語として**TypeScript**を使用し、フレームワークとして使用したのは**Next.js**です。App Router を採用し、React Server Components (RSC) と Client Components を適切に使い分けています。
+
+- [Next.js](https://nextjs.org) (15.5.2) - React フレームワーク (App Router)
+- [React](https://reactjs.org) (19.1.0) - UI ライブラリ
+- [TypeScript](https://www.typescriptlang.org/) (5 系) - 型安全性
+- [AWS Amplify](https://docs.amplify.aws/) (6.15.6) - Cognito 認証
+- [TailwindCSS](https://tailwindcss.com/) (4 系) - CSS フレームワーク
+- [Radix UI](https://www.radix-ui.com/) - アクセシブルな UI コンポーネント
+- [SWR](https://swr.vercel.app/) (2.3.6) - データフェッチング
+- [Recharts](https://recharts.org/) (2.15.4) - チャート描画
+- [date-fns](https://date-fns.org/) (4.1.0) - 日付処理
+- [Lucide React](https://lucide.dev/) - アイコンライブラリ
+- [Sonner](https://sonner.emilkowal.ski/) (2.0.7) - トースト通知
+- [next-themes](https://github.com/pacocoursey/next-themes) (0.4.6) - ダークモード
+- [ESLint](https://eslint.org/) (9.34.0) - リンター
+- [Prettier](https://prettier.io/) (3.6.2) - フォーマッター
+
+**フロントエンドの責任**
+
+- AWS Cognito による認証（ログイン・ログアウト・サインアップ）
+- Amplify によるトークン管理
+- 認証フォームの UI
+- JWT トークン付き API 呼び出し
+- データの表示とユーザーインタラクション
+
+#### バックエンド
+
+バックエンドの開発言語には**PHP**、Web アプリケーションフレームワークには**Laravel**を利用しました。開発環境の構築には、**Docker**と**Docker Compose**を用いており、これを実行することで開発用のサーバーが起動し、データベースや API サーバーを含む環境が整います。
+
+- [PHP](https://www.php.net/) (8.2+) - プログラミング言語
+- [Laravel](https://laravel.com/) (12.0) - Web アプリケーションフレームワーク
+- [MySQL](https://www.mysql.com/) (8.4) - リレーショナルデータベース
+- [Composer](https://getcomposer.org/) - 依存関係管理
+- [AWS SDK for PHP](https://aws.amazon.com/sdk-for-php/) (3.356) - AWS 連携
+- [Firebase JWT](https://github.com/firebase/php-jwt) (6.11) - JWT 検証
+- [PHPUnit](https://phpunit.de/) (11.5.3) - テストフレームワーク
+- [Laravel Pint](https://laravel.com/docs/12.x/pint) (1.13) - コードスタイル整形
+- [Laravel Sail](https://laravel.com/docs/12.x/sail) (1.41) - Docker 開発環境
+
+**バックエンドの責任**
+
+- JWT トークン検証（Cognito 発行トークン）
+- データベース操作（CRUD）
+- ビジネスロジック（予算計算、集計など）
+- API エンドポイント提供
+- データバリデーション
+
+**認証**
+
+認証には**AWS Amplify v6**を用い、Cognito 認証を実装しています。
+
+### 4-2.データベース設計（ER 図）
+
+ER 図を後から追加
+
+### 4-3.インフラ構成図
+
+**開発環境**
+
+- [Docker](https://www.docker.com/) - コンテナ管理
+- [Docker Compose](https://docs.docker.com/compose/) - マルチコンテナ管理
+- [AWS Cognito](https://aws.amazon.com/cognito/) - 認証・認可サービス
+- [Nginx](https://nginx.org/) - Web サーバー
+
+**本番環境**
+
+AWS のインフラ構成図を後から追加
+
+## 5.アプリ開発の振り返り
+
+## 6.今後の展望

--- a/backend/app/Http/Controllers/Api/SettingController.php
+++ b/backend/app/Http/Controllers/Api/SettingController.php
@@ -16,31 +16,37 @@ use Illuminate\Support\Facades\Log;
 
 class SettingController extends Controller
 {
-    public function entry(Request $request, $userName, $partnerId = null): JsonResponse
+    public function entry(Request $request): JsonResponse
     {
         $user = $request->attributes->get('auth_user');
 
+        // リクエストボディからデータを取得
+        $userName = $request->input('name');
+        $partnerId = $request->input('partner_id');
+
         // ユーザー名を更新
-        try {
-            if (mb_strlen($userName) > 10) {
+        if ($userName !== null) {
+            try {
+                if (mb_strlen($userName) > 10) {
+                    return response()->json([
+                        'status' => false,
+                        'message' => 'ユーザー名は10文字以内で入力してください',
+                    ], 422);
+                }
+
+                $user->update(['name' => $userName]);
+            } catch (Exception $e) {
+                Log::error('ユーザー名の更新に失敗しました', [
+                    'user_id' => $user->id,
+                    'user_name' => $userName,
+                    'error' => $e->getMessage(),
+                ]);
+
                 return response()->json([
                     'status' => false,
-                    'message' => 'ユーザー名は10文字以内で入力してください',
-                ], 422);
+                    'message' => 'ユーザー名の更新に失敗しました',
+                ], 500);
             }
-
-            $user->update(['name' => $userName]);
-        } catch (Exception $e) {
-            Log::error('ユーザー名の更新に失敗しました', [
-                'user_id' => $user->id,
-                'user_name' => $userName,
-                'error' => $e->getMessage(),
-            ]);
-
-            return response()->json([
-                'status' => false,
-                'message' => 'ユーザー名の更新に失敗しました',
-            ], 500);
         }
 
         // パートナーを設定

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -69,7 +69,7 @@ Route::middleware('cognito')->group(function () {
 
     // 設定関連のルート
     Route::prefix('partner-setting')->group(function () {
-        Route::post('/{userName}/{partnerId?}', [SettingController::class, 'entry']);
+        Route::post('/', [SettingController::class, 'entry']);
         Route::delete('/reset', [SettingController::class, 'reset']);
     });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -166,12 +166,13 @@ export async function postPartnerSetting(
   userName: string,
   partnerId?: string
 ): Promise<Response> {
-  return await fetchApi<Response>(
-    `/partner-setting/${userName}${partnerId ? `/${partnerId}` : ""}`,
-    {
-      method: "POST",
-    }
-  );
+  return await fetchApi<Response>("/partner-setting", {
+    method: "POST",
+    body: JSON.stringify({
+      name: userName,
+      partner_id: partnerId || null,
+    }),
+  });
 }
 
 // パートナー設定の解除


### PR DESCRIPTION
パートナー設定時に接続するAPIのパスを変更
前：partner-setting/userName/partnerid
後：partner-setting

ここまでの開発から以下の実装方針を固めていた。
・APIのパスに含めるのはユーザーモード及びファイナンスモードに限定
・そのほかの情報はクエリとして渡す

固めた実装方針にそぐわないAPIパスだったため修正。

※補足
作成中のREADMEの変更も、誤って一緒にプッシュしてます