### PR TITLE
Log::warningをLog::errorに変更してCloudWatch Logsで確認できるようにする

### DIFF
--- a/backend/app/Http/Controllers/Api/SettingController.php
+++ b/backend/app/Http/Controllers/Api/SettingController.php
@@ -18,7 +18,7 @@ class SettingController extends Controller
 {
     public function entry(Request $request): JsonResponse
     {
-        Log::warning('[DEBUG] entry method 開始しました', [
+        Log::error('[DEBUG] entry method 開始しました', [
             'request_data' => $request->all(),
         ]);
 
@@ -37,7 +37,7 @@ class SettingController extends Controller
         $userName = $request->input('name');
         $partnerId = $request->input('partner_id');
 
-        Log::warning('[DEBUG] パラメータを取得しました', [
+        Log::error('[DEBUG] パラメータを取得しました', [
             'userName' => $userName,
             'partnerId' => $partnerId,
         ]);
@@ -70,11 +70,11 @@ class SettingController extends Controller
         // パートナーを設定
         if ($user->couple_id === null && $partnerId !== null) {
             try {
-                Log::warning('[DEBUG] パートナーを検索しました');
+                Log::error('[DEBUG] パートナーを検索しました');
                 $partner = User::where('user_id', $partnerId)->first();
 
                 if (! $partner || $user->id === $partner->id) {
-                    Log::warning('[DEBUG] パートナーが見つかりません', [
+                    Log::error('[DEBUG] パートナーが見つかりません', [
                         'partner_found' => $partner ? 'yes' : 'no',
                         'same_user' => $partner && $user->id === $partner->id,
                     ]);
@@ -85,14 +85,14 @@ class SettingController extends Controller
                     ], 404);
                 }
 
-                Log::warning('[DEBUG] setPartnerを呼び出しました', [
+                Log::error('[DEBUG] setPartnerを呼び出しました', [
                     'user_id' => $user->id,
                     'partner_id' => $partner->id,
                 ]);
 
                 $result = User::setPartner($user, $partner);
 
-                Log::warning('[DEBUG] setPartnerの結果を取得しました', ['result' => $result]);
+                Log::error('[DEBUG] setPartnerの結果を取得しました', ['result' => $result]);
 
                 if (! $result) {
                     Log::error('[DEBUG] setPartnerがfalseを返しました');

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -67,7 +67,7 @@ class User extends Authenticatable
         DB::beginTransaction();
 
         try {
-            Log::warning('[DEBUG] Couple作成開始', [
+            Log::error('[DEBUG] Couple作成開始', [
                 'user_user_id' => $user->user_id,
                 'partner_user_id' => $partner->user_id,
             ]);
@@ -76,12 +76,12 @@ class User extends Authenticatable
                 'name' => $user->user_id.' & '.$partner->user_id,
             ]);
 
-            Log::warning('[DEBUG] Couple作成成功', [
+            Log::error('[DEBUG] Couple作成成功', [
                 'couple_id' => $couple->id,
                 'couple_name' => $couple->name,
             ]);
 
-            Log::warning('[DEBUG] User更新開始', [
+            Log::error('[DEBUG] User更新開始', [
                 'user_id' => $user->id,
                 'couple_id' => $couple->id,
             ]);
@@ -91,9 +91,9 @@ class User extends Authenticatable
                 'pair_index' => 1,
             ]);
 
-            Log::warning('[DEBUG] User更新成功');
+            Log::error('[DEBUG] User更新成功');
 
-            Log::warning('[DEBUG] Partner更新開始', [
+            Log::error('[DEBUG] Partner更新開始', [
                 'partner_id' => $partner->id,
                 'couple_id' => $couple->id,
             ]);
@@ -103,11 +103,11 @@ class User extends Authenticatable
                 'pair_index' => 2,
             ]);
 
-            Log::warning('[DEBUG] Partner更新成功');
+            Log::error('[DEBUG] Partner更新成功');
 
-            Log::warning('[DEBUG] トランザクションコミット開始');
+            Log::error('[DEBUG] トランザクションコミット開始');
             DB::commit();
-            Log::warning('[DEBUG] トランザクションコミット成功');
+            Log::error('[DEBUG] トランザクションコミット成功');
 
             return true;
         } catch (\Exception $e) {


### PR DESCRIPTION
本番環境にてパートナー設定が実行できない問題の原因特定のため、CloudWatchでログを確認したい。
ここまではwarningでログを出力させていたが、errorにすると表示されるのではとの提案あり。
代替案がないため、errorも試してみる。