### PR TITLE
pair_indexカラムの削除

### DIFF
--- a/backend/app/Http/Controllers/Api/SettingController.php
+++ b/backend/app/Http/Controllers/Api/SettingController.php
@@ -142,12 +142,10 @@ class SettingController extends Controller
 
             $user->update([
                 'couple_id' => null,
-                'pair_index' => null,
             ]);
 
             $partner->update([
                 'couple_id' => null,
-                'pair_index' => null,
             ]);
 
             Couple::where('id', $coupleId)->delete();

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -19,7 +19,6 @@ class User extends Authenticatable
         'user_id',
         'cognito_sub',
         'couple_id',
-        'pair_index',
     ];
 
     /**
@@ -88,7 +87,6 @@ class User extends Authenticatable
 
             $user->update([
                 'couple_id' => $couple->id,
-                'pair_index' => 1,
             ]);
 
             Log::error('[DEBUG] User更新成功');
@@ -100,7 +98,6 @@ class User extends Authenticatable
 
             $partner->update([
                 'couple_id' => $couple->id,
-                'pair_index' => 2,
             ]);
 
             Log::error('[DEBUG] Partner更新成功');

--- a/backend/database/migrations/2025_12_14_233627_drop_pair_index_column_to_users_table.php
+++ b/backend/database/migrations/2025_12_14_233627_drop_pair_index_column_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('pair_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->index('pair_index');
+        });
+    }
+};

--- a/backend/database/seeders/GuestAccountSeeder.php
+++ b/backend/database/seeders/GuestAccountSeeder.php
@@ -17,7 +17,6 @@ class GuestAccountSeeder extends Seeder
             'user_id' => 'guestuser1',
             'cognito_sub' => 'c704eaf8-a0d1-7029-d1df-8730f8653078',
             'couple_id' => null,
-            'pair_index' => null,
         ]);
     }
 }


### PR DESCRIPTION
パートナー設定でエラーが発生していた原因が判明。

■原因
・pair_indexカラムにunique制約が付与されていた（本来は同じカップルidで1と2が被らないようにするためだった）
・１つでもパートナー設定が行われているとpair_indexの入力が行えなくなりエラーとなっていた

■対策
使用しないカラムだったため、削除することを決定。

今後パートナー設定の承認機能を設ける際に似たカラムが必要になる。
が、申請に関する情報は個人ではなく２者間の問題のため、userテーブルではなくcoupleテーブルに設置予定。