### PR TITLE
パートナーのDBIDを取得して明細の仕分け機能を正しく動作させるように修正

### DIFF
--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -23,12 +23,19 @@ class UserController extends Controller
             $partnerUserId = User::getPartnerUserId($user);
         }
 
+        // パートナーのidを取得
+        $partnerId = null;
+        if ($user->couple_id) {
+            $partnerId = User::getPartnerId($user->id);
+        }
+
         return response()->json([
             'id' => $user->id,
             'user_id' => $user->user_id,
             'name' => $user->name,
             'couple_id' => $user->couple_id,
             'partner_user_id' => $partnerUserId,
+            'partner_id' => $partnerId,
         ]);
     }
 

--- a/frontend/src/components/dashboard/SpendingPerMonth/SpendingDetailList.tsx
+++ b/frontend/src/components/dashboard/SpendingPerMonth/SpendingDetailList.tsx
@@ -16,7 +16,7 @@ export function SpendingDetailList({
   );
 
   const userId = userInfo.id;
-  const partnerId = userInfo.partner_user_id || userInfo.couple_id;
+  const partnerId = userInfo.partner_id;
 
   // 各ユーザーの支払いデータを取得
   const myPayments = paymentRecordsByUser[userId] || [];

--- a/frontend/src/components/dashboard/SpendingPerMonth/SpendingDonutChart.tsx
+++ b/frontend/src/components/dashboard/SpendingPerMonth/SpendingDonutChart.tsx
@@ -69,7 +69,7 @@ export function SpendingDonutChart({
                 ¥ {viewData?.userTotals?.[userInfo.id]?.toLocaleString() ?? "0"}
               </td>
             </tr>
-            {user === "common" && userInfo.partner_user_id && (
+            {user === "common" && userInfo.partner_id && (
               <tr>
                 <td className="text-lg py-2 [vertical-align:bottom]">
                   {userInfo.partner_user_id ?? "パートナー"}の負担
@@ -77,7 +77,7 @@ export function SpendingDonutChart({
                 <td className="text-4xl py-2 text-left">
                   ¥{" "}
                   {viewData?.userTotals?.[
-                    userInfo.partner_user_id
+                    userInfo.partner_id
                   ]?.toLocaleString() ?? "0"}
                 </td>
               </tr>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -28,6 +28,7 @@ const initialUserInfo: UserInfo = {
   name: "",
   couple_id: null,
   partner_user_id: null,
+  partner_id: null,
   email: null,
 };
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -319,6 +319,7 @@ export async function getCurrentUserInfo(): Promise<UserInfo | null> {
       name: user.name,
       couple_id: user.couple_id || null,
       partner_user_id: user.partner_user_id || null,
+      partner_id: user.partner_id ? String(user.partner_id) : null,
       email: email,
     };
 

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -6,6 +6,7 @@ export interface User {
   cognito_sub: string;
   couple_id: string | null;
   partner_user_id: string | null;
+  partner_id: number | null;
   created_at: string;
 }
 
@@ -16,6 +17,7 @@ export interface UserInfo {
   name: string;
   couple_id: string | null;
   partner_user_id: string | null;
+  partner_id: string | null;
   email: string | null;
 }
 


### PR DESCRIPTION
事象：支払者をパートナーに設定したpaymentデータが表示されない
原因と解決策：
取得していたpartner_user_idはパートナーに割り振られたユーザーIDであり、誤った値を参照させていた。
そこで、パートナーのDBのIDを取得する処理を追加し、DBのIDに一致するpaymentデータを表示する処理に変更した。